### PR TITLE
UAT Testing Fixes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -101,10 +101,11 @@
     font-weight: lighter !important;
 }
 
+/*noinspection CssUnresolvedCustomProperty*/
 .format-menutab-hidden-sections {
     border-style: dotted;
     border-width: 3px;
-    border-color: darkblue;
+    border-color: var(--primary);
     padding: 10px;
 }
 
@@ -145,8 +146,8 @@ When small screen, don't show the "filler sections" (#section-) <-- null
     body[theme-mode='dark'] #section- {
         display: none;
     }
-}
 
-.section-zero-header button.btn-outline-menutab.btn-menutab-lg::after {
-    content: "" !important;
+    .section-zero-header button.btn-outline-menutab.btn-menutab-lg::after {
+        content: "" !important;
+    }
 }

--- a/templates/course_home_page.mustache
+++ b/templates/course_home_page.mustache
@@ -221,12 +221,6 @@ no sectionid, Links and badges will not be printed on the card.
 }}
 <style>
 
-    @media (max-width: 768px) {
-        header#page-header {
-            display: none !important;
-        }
-    }
-
     div[role='main'] {
         padding-left: 0 !important;
         padding-right: 0 !important;
@@ -235,6 +229,10 @@ no sectionid, Links and badges will not be printed on the card.
     header#page-header {
         height: 0;
         opacity: 0;
+    }
+
+    #page-content {
+        padding-top: 0 !important;
     }
 
     #format_menutab_home_page_image {
@@ -290,7 +288,7 @@ no sectionid, Links and badges will not be printed on the card.
     <input type="hidden" id="format-menutab-courseid" value="{{courseid}}">
     <h2 class="accesshide">{{{title}}}</h2>
     {{{completionhelp}}}
-    <div class="row mb-1">
+    <div class="row mb-3">
         <div class="col">
             {{^course_image}} <!-- if there is no image add a card-->
             <div class="card">


### PR DESCRIPTION
Fixed:

> For menutab format, when in editing mode and when the settings "Group hidden sections" is set to yes, Hidden sections show up in a "box" at the bottom of the course. Notice the blue dotted border.

And more dark mode support :)