### PR TITLE
Fix: only hide modules with eye-closed restriction, not eye-open rest…

### DIFF
--- a/classes/output/course_output.php
+++ b/classes/output/course_output.php
@@ -806,9 +806,11 @@ class course_output implements \renderable, \templatable
             if ($mod->deletioninprogress) {
                 continue;
             }
-            // Skip modules that are completely hidden from the current user.
-            // This covers activities with "Restrict Access" set to hidden (eye icon closed).
-            if (!$mod->uservisible) {
+            // Skip modules that are completely hidden from the current user with no availability
+            // message to display. This covers activities with "Restrict Access" set to hidden
+            // (eye icon closed). When the eye icon is open and the restriction is not met,
+            // availableinfo is non-empty and the module should still render with a lock message.
+            if (!$mod->uservisible && empty($mod->availableinfo)) {
                 continue;
             }
 
@@ -875,9 +877,11 @@ class course_output implements \renderable, \templatable
                     if ($delegated_mod->deletioninprogress) {
                         continue;
                     }
-                    // Skip modules that are completely hidden from the current user.
-                    // This covers activities with "Restrict Access" set to hidden (eye icon closed).
-                    if (!$delegated_mod->uservisible) {
+                    // Skip modules that are completely hidden from the current user with no availability
+                    // message to display. This covers activities with "Restrict Access" set to hidden
+                    // (eye icon closed). When the eye icon is open and the restriction is not met,
+                    // availableinfo is non-empty and the module should still render with a lock message.
+                    if (!$delegated_mod->uservisible && empty($delegated_mod->availableinfo)) {
                         continue;
                     }
 
@@ -951,6 +955,13 @@ class course_output implements \renderable, \templatable
         foreach ($cmids as $index => $cmid) {
             $mod = $this->modinfo->get_cm($cmid);
             if ($mod->deletioninprogress) {
+                continue;
+            }
+            // Skip modules that are completely hidden from the current user with no availability
+            // message to display. This covers activities with "Restrict Access" set to hidden
+            // (eye icon closed). When the eye icon is open and the restriction is not met,
+            // availableinfo is non-empty and the module should still render with a lock message.
+            if (!$mod->uservisible && empty($mod->availableinfo)) {
                 continue;
             }
 


### PR DESCRIPTION
…ricted

Change the uservisible check to also require empty availableinfo before skipping a module. This mirrors core Moodle's course_section_cm_list_item() behaviour:
- Eye closed + restriction not met: uservisible=false, availableinfo=''  -> hidden
- Eye open + restriction not met:  uservisible=false, availableinfo='...' -> shown with lock message
- Normal visible module:           uservisible=true                       -> shown normally

The previous check (!$mod->uservisible) was too broad and also hid activities where the eye icon was left open.

(cherry picked from commit cb7151321502399d295edea7ff251bcb158e93fc)